### PR TITLE
Update LAD to work on latest patch

### DIFF
--- a/lad/livesplit_lad.asl
+++ b/lad/livesplit_lad.asl
@@ -27,9 +27,8 @@ init
 {
     switch (modules.First().ModuleMemorySize)
     {
+        case 414711808:
         case 434040832:
-            version = "1.9.2";
-            break;
         case 436711424:
             version = "1.9.2";
             break;


### PR DESCRIPTION
Pointer for latest version still works so just have 3 different memory size values use the same version

(putting empty case statements will just make it use the next block's code, if you'd rather it sets the version explicitly for each I can change it)